### PR TITLE
Add matrix.to URL inplace of deprecated riot.im

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <li><a href="https://twitter.com/ilugdelhi" target="_blank" rel=external >Twitter</a></li>
             <li><a href="https://t.me/joinchat/AmwdvEAc48xN_P0xRaR_7Q" rel=external >Telegram</a></li>
             <li><a href="https://www.reddit.com/r/ILUGD/" target="_blank" rel=external >Reddit</a></li>
-            <li><a href="https://riot.im/app/#/room/#ilugd:matrix.org" target="_blank" rel=external >Matrix</a></li>
+            <li><a href="https://matrix.to/#/#ilugd:matrix.org" target="_blank" rel=external >Matrix</a></li>
             <li><a href="https://web.libera.chat/#ilugd" alt="IRC on Libera" target="_blank" rel=external>IRC on Libera</a></li>
           </ul>
         </li>


### PR DESCRIPTION
riot.im (now deprecated) opens Element client in browser. Switched to matrix.to URL which gives option for Element client and bunch of other ways to enter the channel through native matrix applications.