### PR TITLE
Added Code of Conduct page to ILUG-Delhi website

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -169,3 +169,46 @@ a {
     animation: octocat-wave 560ms ease-in-out;
   }
 }
+/* ----------------------------
+   Code of Conduct page styles
+   ---------------------------- */
+.page-coc {
+  max-width: 900px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.page-coc h1 {
+  text-align: center;
+  margin: 0.6em 0 0.4em;
+}
+
+.page-coc h2 {
+  font-size: 28px;
+  margin: 1.2em 0 0.4em;
+}
+
+.page-coc p {
+  font-size: 19px;
+  line-height: 1.6;
+  margin: 0.6em 0;
+}
+
+.page-coc ul {
+  margin: 0.4em 0 0.9em;
+  padding-left: 1.2em;
+}
+
+.page-coc li {
+  font-size: 19px;
+  line-height: 1.6;
+  margin: 0.35em 0;
+}
+
+.page-coc a {
+  border-bottom: 1px solid #00cc88;
+}
+
+.page-coc a:hover {
+  border-bottom: 1px solid transparent;
+}

--- a/coc.html
+++ b/coc.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Indian Linux User Group Delhi</title>
+    <link href="https://fonts.googleapis.com/css?family=PT+Sans:400,700" rel="stylesheet">
+    <!--<link href="https://fonts.googleapis.com/css?family=Space+Mono" rel="stylesheet">-->
+  <link rel="stylesheet" type="text/css" href="assets/css/main.css">
+</head>
+
+<a href="https://github.com/ILUGD/ILUGD.github.io" class="github-fork" target="_blank" aria-label="Fork me on GitHub">
+  <svg width="80" height="80" viewBox="0 0 250 250"
+    style="fill:#64CEAA; color:#fff; position:absolute; top:0; border:0; right:0;">
+  <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+  <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+      fill="currentColor" style="transform-origin:130px 106px;" class="octo-arm"></path>
+  <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+      fill="currentColor" class="octo-body"></path>
+  </svg>
+</a>
+
+<body class="page-home page-coc">
+  <section>
+    <h1>Code of Conduct</h1>
+    <h2>Pledge for all members</h2>
+    <p>In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our community, projects and our meetup groups and physical location/venues, a harassment-free experience for everyone. Regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.</p>
+    <h2 >Standards for the Community</h2>
+    <p>Examples of behaviour that contribute to create a positive environment include:</p>
+    <ul>
+      <li>Using welcoming and inclusive language and being respectful of differing viewpoints and experiences</li>
+      <li>Gracefully accepting constructive criticism and focusing on what is best for the community</li>
+      <li>Showing empathy towards other community members</li>
+      <li>Respecting people's time and privacy and not DMing anyone on official online forums without prior permission </li>
+      <li>Not intervening speakers during meetups with the intention of mocking</li>
+      <li>Using and promotion use of gender neutral pronouns</li>
+    </ul>
+    <p>Examples of unacceptable behaviour by participants include:</p>
+    <ul>
+      <li>Use of sexualised language or imagery and unwelcome sexual attention or advances</li>
+      <li>Use of sexist or racist comments, discrimination or encouragement ofm exclusions</li>
+      <li>Public or private harassment i.e. trolling, insulting/derogatory comments, mocking, abrupt language and personal/political attack in events and official forums</li>
+      <li>Publishing other's private information, such as a physical or electronic address, without explicit permission</li>
+      <li>Reaching out to individual directly or as a community representative without prior permission in/out of official group</li>
+      <li>Vandalizing venues/ Stealing of personal property or using it without permission</li>
+      <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+    </ul>
+    <h2>Responsibilities as an Organizer and Volunteer</h2>
+    <p>Organisers and Volunteers are responsible for clarifying the standards of acceptable behaviour and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behaviour.</p>
+    <p>For community projects, project maintainers have the rights and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to <em>this</em> Code of Conduct, or to ban temporarily or permanently any contributor for other behaviours that they deem inappropriate, threatening, offensive, or harmful.</p>
+    <p>In case of CoC violation during physical events, organiser can ask the personnel to immediately leave the event and failure to comply may result in involving the legal bodies of that area. </p>
+    <p>In case of CoC violation on any community online forums, organisers and volunteers shall keep the identity of personnal reporting the incident as discrete.</p>
+    <h2>Scope of this Community</h2>
+    <p>This Code of Conduct applies to all community spaces, online forums and in physical public events when an individual is representing the community in any form.</p>
+    <p>Examples of representing the community include : using an official community name, logo, address, posting via an official social media account, or acting as an appointed representative at an online or offline event. </p>
+    <p>Representation of the community may be further defined and clarified by the community leads.</p>
+    <h2>Enforcement</h2>
+    <p>Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the organisers and volunteers on telegram group or by emailing at : <a href="mailto:ilugdelhi@gmail.com">ilugdelhi@gmail.com</a></p>
+    <p>All complaints will be reviewed and investigated and result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+    Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.</p>
+    <p>All members joining community events, online forums are adhere to the CoC and the safety disclaimers implicitly. </p>
+    <h2>Attribution</h2>
+    <p>This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at <a href="http://contributor-covenant.org/version/1/4">http://contributor-covenant.org/version/1/4</a></p>     
+  </section>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,8 @@
         </li>
         <li><a href="knowledgebase.html" target="_blank" alt="Knowledgebase">Knowledgebase</a></li>
         <li><a href="announcements.html" target="_blank" alt="Announcements">Announcements</a></li>
-	<li><a href="planet" target="_blank" alt="Planet ILUG-D">Planet</a></li>
+	      <li><a href="planet" target="_blank" alt="Planet ILUG-D">Planet</a></li>
+        <li><a title='Code of Conduct' alt="COC" target="_blank" rel=external href="coc.html">COC</a></li>
       </ul>
     </section>
     <div class="section--next_event" data-meetup-group="ILUGDelhi"></div>


### PR DESCRIPTION
### Context
A **Code of Conduct (CoC)** already existed in the GitHub repository, but it was not accessible or visible on the ILUG-Delhi website.

### Changes
- Brought the existing **GitHub CoC content to the website**
- Added a clear navigation link so community members and event participants can easily access it
- No content ownership changed — this is a visibility and sync update only

### Impact
This ensures ILUG-Delhi community standards are publicly visible on the website, helping newcomers, contributors, and meetup attendees understand expected behavior without needing to browse the repository.

---

Thanks to the maintainers and community for reviewing this sync!  
— *Sachin Kumar Jha*